### PR TITLE
Fixing typos

### DIFF
--- a/oct_11.md
+++ b/oct_11.md
@@ -203,7 +203,7 @@ Node::Node(const Node &other) :
 
 // Correct: has base case
 Node::Node(const Node &other) :
-  data{other.data}, next{other.next ? Node{*other.next} : nullptr} {
+  data{other.data}, next{other.next ? new Node{*other.next} : nullptr} {
 }
 ```
 

--- a/oct_16.md
+++ b/oct_16.md
@@ -21,7 +21,7 @@ string s{"Hello"}; // Same as above
 ```
 
 * One parameter constructors create implicit/automatic conversions
-* Disallow the single parameter conversion, use the `explicite` keyword:
+* Disallow the single parameter conversion, use the `explicit` keyword:
 
 ```cpp
 struct Node {


### PR DESCRIPTION
You forgot new. And made a spelling mistake for explicit. 

- Just wanted to help out since I'm forking your notes. :) 